### PR TITLE
Feature/prepare consumer backend deployment cmp 396

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -8,7 +8,7 @@ name: "Publish docker images"
 on:
   push:
 
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "feature/prepare_consumer_backend_deployment_cmp-396" ]
 
     # Publish semver tags as releases.
     # tags: [ 'v*.*.*' ]

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -15,16 +15,17 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: "consumer-ui"
+  CONSUMER_UI_IMAGE_NAME: "consumer-ui"
+  CONSUMER_BACKEND_IMAGE_NAME: "product-pass-consumer-backend"
   IMAGE_TAG: ${{ github.sha }}
+  JAVA_VERSION: 17
     
 jobs:
   build:
 
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docker
+    permissions:
+      packages: write
 
     steps:
       - name: Checkout repository
@@ -46,4 +47,22 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.CONSUMER_UI_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '${{ env.JAVA_VERSION }}'
+          distribution: 'adopt'
+      
+      - name:  Build consumer backend with maven
+        run: |
+          cd consumer-backend/materialpass
+          mvn -B clean install
+        
+      - name: Build and push
+        id: build-and-push-backend
+        uses: docker/build-push-action@v3
+        with:
+          context: consumer-backend/materialpass
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.CONSUMER_BACKEND_IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -8,7 +8,7 @@ name: "Publish docker images"
 on:
   push:
 
-    branches: [ "main", "develop", "feature/prepare_consumer_backend_deployment_cmp-396" ]
+    branches: [ "main", "develop" ]
 
     # Publish semver tags as releases.
     # tags: [ 'v*.*.*' ]
@@ -34,7 +34,7 @@ jobs:
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
-      - name: Build and push
+      - name: Build and push frontend
         id: build-and-push-frontend
         uses: docker/build-push-action@v3
         with:
@@ -59,7 +59,7 @@ jobs:
           cd consumer-backend/materialpass
           mvn -B clean install
         
-      - name: Build and push
+      - name: Build and push backend
         id: build-and-push-backend
         uses: docker/build-push-action@v3
         with:

--- a/consumer-backend/materialpass/Dockerfile
+++ b/consumer-backend/materialpass/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:17-alpine
+
+RUN addgroup -g 10001 appgroup \
+	&& adduser -u 10000 -g 10001 -h /home/appuser -D appuser
+
+WORKDIR /app
+
+COPY  ./target .
+COPY  ./data ./data/
+COPY  ./log ./log/
+
+#HEALTHCHECK --interval=60s --timeout=4s CMD curl -f http://localhost:8080/health || exit 1
+HEALTHCHECK NONE
+
+
+# add permissions for a user
+RUN chown -R appuser:appuser /app && chmod -R 755 /app
+
+USER appuser
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "./materialpass-0.0.1-SNAPSHOT.jar"]

--- a/deployment/helm/consumer-backend/.helmignore
+++ b/deployment/helm/consumer-backend/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/helm/consumer-backend/Chart.yaml
+++ b/deployment/helm/consumer-backend/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: consumer-backend
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/deployment/helm/consumer-backend/templates/NOTES.txt
+++ b/deployment/helm/consumer-backend/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "consumer-backend.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "consumer-backend.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "consumer-backend.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "consumer-backend.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/deployment/helm/consumer-backend/templates/_helpers.tpl
+++ b/deployment/helm/consumer-backend/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "consumer-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "consumer-backend.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "consumer-backend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "consumer-backend.labels" -}}
+helm.sh/chart: {{ include "consumer-backend.chart" . }}
+{{ include "consumer-backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "consumer-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "consumer-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "consumer-backend.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "consumer-backend.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/consumer-backend/templates/deployment.yaml
+++ b/deployment/helm/consumer-backend/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "consumer-backend.fullname" . }}
+  labels:
+    {{- include "consumer-backend.labels" . | nindent 4 }}
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "consumer-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "consumer-backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:          
+            - name: "VUE_APP_CLIENT_ID"
+              valueFrom:
+                secretKeyRef:
+                  key:  clientId
+                  name: avp-cx-registry-auth
+            - name: "VUE_APP_CLIENT_SECRET"
+              valueFrom:
+                secretKeyRef:
+                  key:  clientSecret
+                  name: avp-cx-registry-auth
+            - name: "X_API_KEY"
+              valueFrom:
+                secretKeyRef:
+                  key:  xApiKey
+                  name: avp-edc-oauth
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/consumer-backend/templates/ingress.yaml
+++ b/deployment/helm/consumer-backend/templates/ingress.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "consumer-backend.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "consumer-backend.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 8080
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: 8080
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/consumer-backend/templates/secret.yaml
+++ b/deployment/helm/consumer-backend/templates/secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: avp-cx-registry-auth
+  labels:
+    {{- include "consumer-backend.labels" . | nindent 4 }}
+  namespace: {{ .Values.namespace }}
+type: Opaque
+stringData:
+  clientId: {{ .Values.avp.helm.clientId }}
+  clientSecret: {{ .Values.avp.helm.clientSecret }}
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: avp-edc-oauth
+  labels:
+    {{- include "consumer-backend.labels" . | nindent 4 }}
+  namespace: {{ .Values.namespace }}
+type: Opaque
+stringData:
+  xApiKey: {{ .Values.avp.helm.xApiKey }}

--- a/deployment/helm/consumer-backend/templates/service.yaml
+++ b/deployment/helm/consumer-backend/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "consumer-backend.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "consumer-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}    # host port
+      targetPort: 8080                      # container port
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "consumer-backend.selectorLabels" . | nindent 4 }}

--- a/deployment/helm/consumer-backend/values-dev.yaml
+++ b/deployment/helm/consumer-backend/values-dev.yaml
@@ -1,0 +1,65 @@
+# Default values for consumer-backend.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+namespace: product-material-pass
+
+image:
+  repository: ghcr.io/catenax-ng/product-battery-passport-consumer-app/consumer-backend
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: "consumer-backend"
+fullnameOverride: "consumer-backend"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  # className: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    #kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+  hosts:
+    - host: materialpass.dev.demo.catena-x.net
+      paths:
+        - path: /backend-service(/|$)(.*)
+          pathType: Prefix
+  tls:
+    - secretName: tls-secret
+      hosts:
+        - materialpass.dev.demo.catena-x.net
+
+avp:
+  helm:
+    clientId: <path:material-pass/data/dev/aasregistry#client.id>
+    clientSecret: <path:material-pass/dev/int/aasregistry#client.secret>
+    xApiKey: <path:material-pass/data/dev/edc/oauth#api.key>
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deployment/helm/consumer-backend/values-dev.yaml
+++ b/deployment/helm/consumer-backend/values-dev.yaml
@@ -6,10 +6,10 @@ replicaCount: 1
 namespace: product-material-pass
 
 image:
-  repository: ghcr.io/catenax-ng/product-battery-passport-consumer-app/consumer-backend
+  repository: ghcr.io/catenax-ng/product-battery-passport-consumer-app
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: placeholder
 
 imagePullSecrets: []
 nameOverride: "consumer-backend"

--- a/deployment/helm/consumer-backend/values-dev.yaml
+++ b/deployment/helm/consumer-backend/values-dev.yaml
@@ -43,7 +43,7 @@ ingress:
 avp:
   helm:
     clientId: <path:material-pass/data/dev/aasregistry#client.id>
-    clientSecret: <path:material-pass/data/dev/int/aasregistry#client.secret>
+    clientSecret: <path:material-pass/data/dev/aasregistry#client.secret>
     xApiKey: <path:material-pass/data/dev/edc/oauth#api.key>
 
 resources: {}

--- a/deployment/helm/consumer-backend/values-dev.yaml
+++ b/deployment/helm/consumer-backend/values-dev.yaml
@@ -43,7 +43,7 @@ ingress:
 avp:
   helm:
     clientId: <path:material-pass/data/dev/aasregistry#client.id>
-    clientSecret: <path:material-pass/dev/int/aasregistry#client.secret>
+    clientSecret: <path:material-pass/data/dev/int/aasregistry#client.secret>
     xApiKey: <path:material-pass/data/dev/edc/oauth#api.key>
 
 resources: {}

--- a/deployment/helm/consumer-backend/values-int.yaml
+++ b/deployment/helm/consumer-backend/values-int.yaml
@@ -6,10 +6,10 @@ replicaCount: 1
 namespace: product-material-pass
 
 image:
-  repository: ghcr.io/catenax-ng/product-battery-passport-consumer-app/consumer-backend
+  repository: ghcr.io/catenax-ng/product-battery-passport-consumer-app
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: placeholder
 
 imagePullSecrets: []
 nameOverride: "consumer-backend"

--- a/deployment/helm/consumer-backend/values-int.yaml
+++ b/deployment/helm/consumer-backend/values-int.yaml
@@ -1,0 +1,65 @@
+# Default values for consumer-backend.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+namespace: product-material-pass
+
+image:
+  repository: ghcr.io/catenax-ng/product-battery-passport-consumer-app/consumer-backend
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: "consumer-backend"
+fullnameOverride: "consumer-backend"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  # className: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    #kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+  hosts:
+    - host: materialpass.int.demo.catena-x.net
+      paths:
+        - path: /backend-service(/|$)(.*)
+          pathType: Prefix
+  tls:
+    - secretName: tls-secret
+      hosts:
+        - materialpass.int.demo.catena-x.net
+
+avp:
+  helm:
+    clientId: <path:material-pass/data/int/aasregistry#client.id>
+    clientSecret: <path:material-pass/data/int/aasregistry#client.secret>
+    xApiKey: <path:material-pass/data/int/edc/oauth#api.key>
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deployment/infrastructure/provider/init-provider.sh
+++ b/deployment/infrastructure/provider/init-provider.sh
@@ -15,6 +15,7 @@ DIGITAL_TWIN_3='urn:uuid:365e6fbe-bb34-11ec-8422-0242ac120002'
 DIGITAL_TWIN_SUBMODEL_ID_3='urn:uuid:61125dc3-5e6f-4f4b-838d-447432b97918'
 
 SERVER_URL='https://materialpass.int.demo.catena-x.net'
+REGISTRY_URL='https://semantics.int.demo.catena-x.net/registry/registry/shell-descriptors'
 
 
 # put access token without 'Bearer ' prefix
@@ -49,7 +50,7 @@ echo
 # To authenticate against CX registry, one needs a valid bearer token which can be issued through postman given the clientId and clientSecret
 echo "Create a DT for asset 1 and register it into CX registry..."
 
-curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/X123456789012X12345678901234566.json"  https://semantics.int.demo.catena-x.net/registry/registry/shell-descriptors
+curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/X123456789012X12345678901234566.json"  $REGISTRY_URL
 echo
 echo
 
@@ -83,7 +84,7 @@ echo
 # To authenticate against CX registry, one needs a valid bearer token which can be issued through postman given the clientId and clientSecret
 echo "Create a DT for asset 2 and register it into CX registry..."
 
-curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/NCR186850B.json" https://semantics.int.demo.catena-x.net/registry/registry/shell-descriptors
+curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/NCR186850B.json" $REGISTRY_URL
 echo
 echo
 
@@ -114,7 +115,7 @@ echo
 # To authenticate against CX registry, one needs a valid bearer token which can be issued through postman given the clientId and clientSecret
 echo "Create a DT for asset 3 and register it into CX registry..."
 
-curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/IMR18650V1.json" https://semantics.int.demo.catena-x.net/registry/registry/shell-descriptors
+curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/IMR18650V1.json" $REGISTRY_URL
 echo
 
 echo 'Provider setup completed...'

--- a/deployment/infrastructure/provider/init-provider_dev.sh
+++ b/deployment/infrastructure/provider/init-provider_dev.sh
@@ -15,6 +15,7 @@ DIGITAL_TWIN_3='urn:uuid:51b1cd81-d03b-441d-a7c2-41ef9d789199'
 DIGITAL_TWIN_SUBMODEL_ID_3='urn:uuid:10d094e0-aecc-4e84-b937-a1d606112cdd'
 
 SERVER_URL='https://materialpass.dev.demo.catena-x.net'
+REGISTRY_URL='https://semantics.dev.demo.catena-x.net/registry/registry/shell-descriptors'
 
 # put access token without 'Bearer ' prefix
 BEARER_TOKEN=''
@@ -47,7 +48,7 @@ echo
 # Create a digital twin and register inside CX registry
 # To authenticate against CX registry, one needs a valid bearer token which can be issued through postman given the clientId and clientSecret
 echo "Create a DT for asset 1 and register it into CX registry..."
-curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/X123456789012X12345678901234566_DEV.json"  https://semantics.int.demo.catena-x.net/registry/registry/shell-descriptors
+curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/X123456789012X12345678901234566_DEV.json"  $REGISTRY_URL
 echo
 echo
 
@@ -78,7 +79,7 @@ echo
 # Create a digital twin and register inside CX registry
 # To authenticate against CX registry, one needs a valid bearer token which can be issued through postman given the clientId and clientSecret
 echo "Create a DT for asset 2 and register it into CX registry..."
-curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/NCR186850B_DEV.json" https://semantics.int.demo.catena-x.net/registry/registry/shell-descriptors
+curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/NCR186850B_DEV.json" $REGISTRY_URL
 echo
 echo
 
@@ -108,7 +109,7 @@ echo
 # Create a digital twin and register inside CX registry
 # To authenticate against CX registry, one needs a valid bearer token which can be issued through postman given the clientId and clientSecret
 echo "Create a DT for asset 3 and register it into CX registry..."
-curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/IMR18650V1_DEV.json" https://semantics.int.demo.catena-x.net/registry/registry/shell-descriptors
+curl -X POST -s --header 'Content-Type: application/json' --header "Authorization: Bearer ${BEARER_TOKEN//[$'\t\r\n ']}"  --data "@resources/digitaltwins/IMR18650V1_DEV.json" $REGISTRY_URL
 echo
 
 echo 'Provider setup completed...'

--- a/src/services/service.const.js
+++ b/src/services/service.const.js
@@ -4,9 +4,10 @@ const AAS_PROXY_URL = "http://localhost:4245";
 const MOCK_AUTH_URL = "https://mock--server.herokuapp.com";
 const GOOGLE_CHART_API_URL = "https://chart.googleapis.com";
 const DUMMY_SERVICE = "http://localhost:3000";
-const INT_SERVER_URL = "https://materialpass.int.demo.catena-x.net";
-const DEV_SERVER_URL = "https://materialpass.dev.demo.catena-x.net";
-const CX_REGISTRY_URL = "https://semantics.int.demo.catena-x.net";
+const SERVER_URL_INT = "https://materialpass.int.demo.catena-x.net";
+const SERVER_URL_DEV = "https://materialpass.dev.demo.catena-x.net";
+const CX_REGISTRY_URL_INT = "https://semantics.int.demo.catena-x.net";
+const CX_REGISTRY_URL_DEV = "https://semantics.dev.demo.catena-x.net";
 const IDP_URL_INT = "https://centralidp.int.demo.catena-x.net/auth/";
 const IDP_URL_DEV = "https://centralidp.dev.demo.catena-x.net/auth/";
 const API_KEY = "X_API_KEY";
@@ -17,6 +18,7 @@ let SERVER_URL = "";
 let INIT_OPTIONS = {};
 let IDP_URL = "";
 let REDIRECT_URI = "";
+let CX_REGISTRY_URL = "";
 let CLIENT_CREDENTIALS = {
   grant_type: 'client_credentials',
   client_id: AAS_REGISTRY_CLIENT,
@@ -32,8 +34,9 @@ if (window.location.href.includes("materialpass.int.demo.catena-x.net")) { // fo
       realm: 'CX-Central',
       onLoad: 'login-required'
     };
-    REDIRECT_URI = INT_SERVER_URL;
+    REDIRECT_URI = SERVER_URL_INT;
     IDP_URL = IDP_URL_INT;
+    CX_REGISTRY_URL = CX_REGISTRY_URL_INT;
 
   }
 }
@@ -45,8 +48,9 @@ else if (window.location.href.includes("materialpass.dev.demo.catena-x.net")) { 
       realm: 'CX-Central',
       onLoad: 'login-required'
     };
-    REDIRECT_URI = DEV_SERVER_URL;
+    REDIRECT_URI = SERVER_URL_DEV;
     IDP_URL = IDP_URL_DEV;
+    CX_REGISTRY_URL = CX_REGISTRY_URL_DEV;
   }
   
 }
@@ -58,7 +62,8 @@ else { // for local run
     onLoad: 'login-required'
   };
   REDIRECT_URI = "http://localhost:8080/";
-  SERVER_URL = INT_SERVER_URL; // this server url should come from DEV. Because DEV is not working at the moment, we use INT Server for testing purpose. Once, DEV is up and running, we change this to DEV.  
+  SERVER_URL = SERVER_URL_INT; // this server url should come from DEV. Because DEV is not working at the moment, we use INT Server for testing purpose. Once, DEV is up and running, we change this to DEV.  
+  CX_REGISTRY_URL = CX_REGISTRY_URL_INT;
 }
 
 export {TWIN_REGISTRY_URL, AAS_PROXY_URL, MOCK_AUTH_URL, GOOGLE_CHART_API_URL, DUMMY_SERVICE, INIT_OPTIONS, REDIRECT_URI, CX_REGISTRY_URL, SERVER_URL, API_KEY, CLIENT_CREDENTIALS, IDP_URL};

--- a/src/services/service.const.js
+++ b/src/services/service.const.js
@@ -7,13 +7,15 @@ const DUMMY_SERVICE = "http://localhost:3000";
 const INT_SERVER_URL = "https://materialpass.int.demo.catena-x.net";
 const DEV_SERVER_URL = "https://materialpass.dev.demo.catena-x.net";
 const CX_REGISTRY_URL = "https://semantics.int.demo.catena-x.net";
-const IDP_URL = "https://centralidp.int.demo.catena-x.net/auth/";
+const IDP_URL_INT = "https://centralidp.int.demo.catena-x.net/auth/";
+const IDP_URL_DEV = "https://centralidp.dev.demo.catena-x.net/auth/";
 const API_KEY = "X_API_KEY";
 const AAS_REGISTRY_CLIENT = 'VUE_APP_CLIENT_ID';
 const AAS_REGISTRY_SECRET = 'VUE_APP_CLIENT_SECRET';
 
 let SERVER_URL = "";
 let INIT_OPTIONS = {};
+let IDP_URL = "";
 let REDIRECT_URI = "";
 let CLIENT_CREDENTIALS = {
   grant_type: 'client_credentials',
@@ -21,17 +23,32 @@ let CLIENT_CREDENTIALS = {
   client_secret: AAS_REGISTRY_SECRET,
   scope: 'openid profile email'
 };
-INIT_OPTIONS = {
-  url: IDP_URL,
-  clientId: 'Cl13-CX-Battery',
-  realm: 'CX-Central',
-  onLoad: 'login-required'
-};
+
 if (window.location.href.includes("materialpass.int.demo.catena-x.net")) { // for integration
-  REDIRECT_URI = INT_SERVER_URL;
+  {
+    INIT_OPTIONS = {
+      url: IDP_URL_INT,
+      clientId: 'Cl13-CX-Battery',
+      realm: 'CX-Central',
+      onLoad: 'login-required'
+    };
+    REDIRECT_URI = INT_SERVER_URL;
+    IDP_URL = IDP_URL_INT;
+
+  }
 }
 else if (window.location.href.includes("materialpass.dev.demo.catena-x.net")) { // for development
-  REDIRECT_URI = DEV_SERVER_URL;
+  {
+    INIT_OPTIONS = {
+      url: IDP_URL_DEV,
+      clientId: 'Cl13-CX-Battery',
+      realm: 'CX-Central',
+      onLoad: 'login-required'
+    };
+    REDIRECT_URI = DEV_SERVER_URL;
+    IDP_URL = IDP_URL_DEV;
+  }
+  
 }
 else { // for local run
   INIT_OPTIONS = {


### PR DESCRIPTION
## What this PR changes/adds

- Prepare helm deployments for the consumer backend system for DEV and rename helm values files for INT
- Creation of  backend Dockerfile
- Creation of Kubernetes manifests and helm resources
- Register docker image in GitHub registry through git workflow file
- Update REGISTRY_URLs init-provider scripts (DEV and INT)
-  Adopt environment-specific settings on runtime for local, DEV and INT in services/service.const.js  
 
## Why it does that

- To run the backend-service as helm deployment in different infrastructure (local, DEV and INT)

## Linked Issue(s)

Closes # <-- [CMP-396](https://jira.catena-x.net/browse/CMP-396)


